### PR TITLE
[v0.0.21] Update 404.html to change GitHub Pages repository name from…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "een-playground",
-  "version": "0.0.20",
-  "lastCommit": "2025-06-14T14:36:09.958Z",
+  "version": "0.0.21",
+  "lastCommit": "2025-06-14T16:06:16.268Z",
   "private": true,
   "type": "module",
   "base": "/een-playground/",

--- a/public/404.html
+++ b/public/404.html
@@ -7,8 +7,8 @@
     // Extract the pathname from the current URL
     const path = window.location.pathname;
     
-    // Get the GitHub Pages repository name (in this case 'een-login')
-    const repoName = '/een-login';
+    // Get the GitHub Pages repository name (in this case 'een-playground')
+    const repoName = '/een-playground';
     
     // Remove the repository name from the path if it's at the beginning
     let redirectPath = path;


### PR DESCRIPTION
… 'een-login' to 'een-playground'